### PR TITLE
Don't initialize rucio clients on import

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.0.3
+current_version = 1.0.4
 commit = True
 tag = True
 files = setup.py admix/__init__.py

--- a/admix/__init__.py
+++ b/admix/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 """Top-level package for aDMIX."""
-__version__ = '1.0.3'
+__version__ = '1.0.4'
 
 import os
 import logging

--- a/admix/clients.py
+++ b/admix/clients.py
@@ -1,0 +1,40 @@
+from rucio.client.client import Client
+from rucio.client.replicaclient import ReplicaClient
+from rucio.client.accountclient import AccountClient
+from rucio.client.rseclient import RSEClient
+from rucio.client.downloadclient import DownloadClient
+from rucio.client.uploadclient import UploadClient
+
+from . import logger
+
+
+rucio_client = None
+replica_client = None
+account_client = None
+rse_client = None
+download_client = None
+upload_client = None
+
+
+def _init_clients():
+    global rucio_client
+    global replica_client
+    global account_client
+    global rse_client
+    global download_client
+    global upload_client
+
+    rucio_client = Client()
+    replica_client = ReplicaClient()
+    account_client = AccountClient()
+    rse_client = RSEClient()
+    download_client = DownloadClient(logger=logger)
+    upload_client = UploadClient()
+
+
+def needs_client(func):
+    def wrapped(*args, **kwargs):
+        if rucio_client is None:
+            _init_clients()
+        return func(*args, **kwargs)
+    return wrapped

--- a/admix/daemons/daemon.py
+++ b/admix/daemons/daemon.py
@@ -53,4 +53,4 @@ class AdmixDaemon:
                     time.sleep(dt)
                     sleep_left = sleep_left - dt
         except KeyboardInterrupt:
-            print("Exiting.")
+            print("\nExiting.")

--- a/admix/downloader.py
+++ b/admix/downloader.py
@@ -1,12 +1,13 @@
 import os
 from argparse import ArgumentParser
-from rucio.client.downloadclient import DownloadClient
+
 import socket
 
 import admix.rucio
-from .utils import  xe1t_runs_collection
+from .utils import xe1t_runs_collection
 from .rucio import list_rules, get_did_type, get_rses
 from . import logger
+from .clients import download_client
 try:
     from straxen import __version__
     straxen_version = __version__
@@ -15,7 +16,6 @@ except ImportError:
 import time
 import utilix
 
-download_client = DownloadClient(logger=logger)
 
 class NoRSEForCountry(Exception):
     pass

--- a/admix/manager.py
+++ b/admix/manager.py
@@ -7,7 +7,7 @@ import tempfile
 
 from packaging import version
 from tqdm import tqdm
-import rucio.common.exception
+from rucio.common.exception import DataIdentifierNotFound
 
 import admix.rucio
 from . import rucio, logger
@@ -94,8 +94,12 @@ def synchronize(run_number, dtype=None):
         base_dict['status'] = None
 
         db_rses = [d['location'] for d in copies]
-        rucio_rules = rucio.list_rules(did)
-        rucio_rses = [r['rse_expression'] for r in rucio_rules]
+        try:
+            rucio_rules = rucio.list_rules(did)
+            rucio_rses = [r['rse_expression'] for r in rucio_rules]
+        except DataIdentifierNotFound:
+            rucio_rses = []
+
         # check for dupicate entries in the runDB
         duplicated_rses = []
         if len(db_rses) != len(set(db_rses)):
@@ -373,7 +377,7 @@ def clean_local_dir(path, before_straxen_version, ensure_rucio=False, dry_run=Tr
                 rules = admix.rucio.get_rses(did, state="OK")
                 if not len(rules):
                     continue
-            except rucio.common.exception.DataIdentifierNotFound:
+            except DataIdentifierNotFound:
                 continue
 
         if dry_run:

--- a/admix/uploader.py
+++ b/admix/uploader.py
@@ -1,12 +1,7 @@
 import os.path
-
-from rucio.client.uploadclient import UploadClient
 from rucio.common.exception import Duplicate, DataIdentifierNotFound
-
 from .rucio import add_scope, list_files
-
-
-upload_client = UploadClient()
+from .clients import upload_client
 
 
 def get_default_scope():

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ with open('requirements.txt') as f:
 
 setup(
     name='xe-admix',
-    version='1.0.3',
+    version='1.0.4',
     description="advanced Data Management In Xenon (aDMIX)",
     long_description=readme + '\n\n' + history,
     url='https://github.com/XENON1T/admix',

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(
     url='https://github.com/XENON1T/admix',
     install_requires=requirements,
     scripts=['bin/admix-download'],
+    packages=find_packages(),
     license="BSD license",
     zip_safe=False,
     keywords='admix',


### PR DESCRIPTION
For times when e.g. rucio server is down, we don't want to get error just when importing admix. 